### PR TITLE
Fixes Individual filtering not being applied if also filtered by global filters (search)

### DIFF
--- a/datatables-jsp/src/main/java/com/github/dandelion/datatables/dao/util/DaoUtils.java
+++ b/datatables-jsp/src/main/java/com/github/dandelion/datatables/dao/util/DaoUtils.java
@@ -29,7 +29,7 @@ public class DaoUtils {
 		 * Step 1.1: global filtering
 		 */
 		if (StringUtils.isNotBlank(criterias.getSearch()) && criterias.hasOneFilterableColumn()) {
-			queryBuilder.append(" WHERE ");
+			queryBuilder.append(" WHERE ( ");
 
 			for (ColumnDef columnDef : criterias.getColumnDefs()) {
 				if (columnDef.isFilterable() && StringUtils.isBlank(columnDef.getSearch())) {
@@ -45,6 +45,8 @@ public class DaoUtils {
 					queryBuilder.append(" OR ");
 				}
 			}
+
+			queryBuilder.append(" ) ");
 		}
 
 		/**

--- a/datatables-thymeleaf/src/main/java/com/github/dandelion/datatables/dao/util/DaoUtils.java
+++ b/datatables-thymeleaf/src/main/java/com/github/dandelion/datatables/dao/util/DaoUtils.java
@@ -29,7 +29,7 @@ public class DaoUtils {
 		 * Step 1.1: global filtering
 		 */
 		if (StringUtils.isNotBlank(criterias.getSearch()) && criterias.hasOneFilterableColumn()) {
-			queryBuilder.append(" WHERE ");
+			queryBuilder.append(" WHERE (");
 
 			for (ColumnDef columnDef : criterias.getColumnDefs()) {
 				if (columnDef.isFilterable() && StringUtils.isBlank(columnDef.getSearch())) {
@@ -45,6 +45,7 @@ public class DaoUtils {
 					queryBuilder.append(" OR ");
 				}
 			}
+			queryBuilder.append(" ) ");
 		}
 
 		/**


### PR DESCRIPTION
Hello,

There was a bug where if you filtered by both global filters, and individual filters, then the individual
filters would be ignored due to them only being checked with the last element, instead of the whole
global filter.

I've applied toe change to datatables-jsp and datatables-thymeleaf examples.
